### PR TITLE
Rebased Mesos patches on top of upstream `release_50`.

### DIFF
--- a/docs/ClangFormatStyleOptions.rst
+++ b/docs/ClangFormatStyleOptions.rst
@@ -1045,6 +1045,9 @@ the configuration (without a prefix: ``Auto``).
        longFunction( // Again a long comment
          arg);
 
+**ArgumentsAndParametersIndentWidth** (``unsigned``)
+  Indent width for arguments and parameters.
+
 **Cpp11BracedListStyle** (``bool``)
   If ``true``, format braced lists as best suited for C++11 braced
   lists.

--- a/include/clang/Format/Format.h
+++ b/include/clang/Format/Format.h
@@ -351,6 +351,9 @@ struct FormatStyle {
   /// \endcode
   bool AlwaysBreakTemplateDeclarations;
 
+  /// \brief Indent width for arguments and parameters.
+  unsigned ArgumentsAndParametersIndentWidth;
+
   /// \brief If ``false``, a function call's arguments will either be all on the
   /// same line or will have one line each.
   /// \code
@@ -1489,6 +1492,8 @@ struct FormatStyle {
                R.AlwaysBreakBeforeMultilineStrings &&
            AlwaysBreakTemplateDeclarations ==
                R.AlwaysBreakTemplateDeclarations &&
+           ArgumentsAndParametersIndentWidth ==
+               R.ArgumentsAndParametersIndentWidth &&
            BinPackArguments == R.BinPackArguments &&
            BinPackParameters == R.BinPackParameters &&
            BreakBeforeBinaryOperators == R.BreakBeforeBinaryOperators &&

--- a/lib/Format/ContinuationIndenter.cpp
+++ b/lib/Format/ContinuationIndenter.cpp
@@ -1084,7 +1084,7 @@ void ContinuationIndenter::moveStatePastScopeOpener(LineState &State,
     if (Current.ParameterCount > 1)
       NestedBlockIndent = std::max(NestedBlockIndent, State.Column + 1);
   } else {
-    NewIndent = Style.ContinuationIndentWidth +
+    NewIndent = Style.ArgumentsAndParametersIndentWidth +
                 std::max(State.Stack.back().LastSpace,
                          State.Stack.back().StartOfFunctionCall);
 

--- a/lib/Format/Format.cpp
+++ b/lib/Format/Format.cpp
@@ -306,6 +306,8 @@ template <> struct MappingTraits<FormatStyle> {
                    Style.AlwaysBreakBeforeMultilineStrings);
     IO.mapOptional("AlwaysBreakTemplateDeclarations",
                    Style.AlwaysBreakTemplateDeclarations);
+    IO.mapOptional("ArgumentsAndParametersIndentWidth",
+                   Style.ArgumentsAndParametersIndentWidth);
     IO.mapOptional("BinPackArguments", Style.BinPackArguments);
     IO.mapOptional("BinPackParameters", Style.BinPackParameters);
     IO.mapOptional("BraceWrapping", Style.BraceWrapping);
@@ -559,6 +561,8 @@ FormatStyle getLLVMStyle() {
   LLVMStyle.AlwaysBreakAfterDefinitionReturnType = FormatStyle::DRTBS_None;
   LLVMStyle.AlwaysBreakBeforeMultilineStrings = false;
   LLVMStyle.AlwaysBreakTemplateDeclarations = false;
+  LLVMStyle.ArgumentsAndParametersIndentWidth = 4;
+  LLVMStyle.BinPackParameters = true;
   LLVMStyle.BinPackArguments = true;
   LLVMStyle.BinPackParameters = true;
   LLVMStyle.BreakBeforeBinaryOperators = FormatStyle::BOS_None;
@@ -702,6 +706,7 @@ FormatStyle getChromiumStyle(FormatStyle::LanguageKind Language) {
   FormatStyle ChromiumStyle = getGoogleStyle(Language);
   if (Language == FormatStyle::LK_Java) {
     ChromiumStyle.AllowShortIfStatementsOnASingleLine = true;
+    ChromiumStyle.ArgumentsAndParametersIndentWidth = 8;
     ChromiumStyle.BreakAfterJavaFieldAnnotations = true;
     ChromiumStyle.ContinuationIndentWidth = 8;
     ChromiumStyle.IndentWidth = 4;

--- a/unittests/Format/FormatTest.cpp
+++ b/unittests/Format/FormatTest.cpp
@@ -10716,6 +10716,7 @@ TEST_F(FormatTest, MunchSemicolonAfterBlocks) {
 TEST_F(FormatTest, ConfigurableContinuationIndentWidth) {
   FormatStyle TwoIndent = getLLVMStyleWithColumns(15);
   TwoIndent.ContinuationIndentWidth = 2;
+  TwoIndent.ArgumentsAndParametersIndentWidth = 2;
 
   EXPECT_EQ("int i =\n"
             "  longFunction(\n"
@@ -10724,6 +10725,7 @@ TEST_F(FormatTest, ConfigurableContinuationIndentWidth) {
 
   FormatStyle SixIndent = getLLVMStyleWithColumns(20);
   SixIndent.ContinuationIndentWidth = 6;
+  SixIndent.ArgumentsAndParametersIndentWidth = 6;
 
   EXPECT_EQ("int i =\n"
             "      longFunction(\n"


### PR DESCRIPTION
This patch rebases the existing changes to `clang-format` on top of the upstream 5.0 release. The required adjustments were mostly mechanic.